### PR TITLE
Update examples with new return variables from run_case

### DIFF
--- a/examples/aluminum_3zone/run.jl
+++ b/examples/aluminum_3zone/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/aluminum_3zone/run_gurobi.jl
+++ b/examples/aluminum_3zone/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/aluminum_3zone/run_with_env.jl
+++ b/examples/aluminum_3zone/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);

--- a/examples/cement_3zone/run.jl
+++ b/examples/cement_3zone/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/cement_3zone/run_gurobi.jl
+++ b/examples/cement_3zone/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/cement_3zone/run_with_env.jl
+++ b/examples/cement_3zone/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);

--- a/examples/electricity_3zone/run.jl
+++ b/examples/electricity_3zone/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/electricity_3zone/run_benders.jl
+++ b/examples/electricity_3zone/run_benders.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__;
+(case, solution) = run_case(@__DIR__;
     planning_optimizer=HiGHS.Optimizer,
     subproblem_optimizer=HiGHS.Optimizer,
     planning_optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3),

--- a/examples/electricity_3zone/run_gurobi.jl
+++ b/examples/electricity_3zone/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/electricity_3zone_multistage/run.jl
+++ b/examples/electricity_3zone_multistage/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/electricity_3zone_multistage/run_benders_HiGHS.jl
+++ b/examples/electricity_3zone_multistage/run_benders_HiGHS.jl
@@ -1,8 +1,9 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__;
+(case, solution) = run_case(@__DIR__;
     planning_optimizer=HiGHS.Optimizer,
     subproblem_optimizer=HiGHS.Optimizer,
     planning_optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3),
-    subproblem_optimizer_attributes=("solver" => "ipm", "run_crossover" => "on", "ipm_optimality_tolerance" => 1e-3));
+    subproblem_optimizer_attributes=("solver" => "ipm", "run_crossover" => "on", "ipm_optimality_tolerance" => 1e-3)
+);

--- a/examples/electricity_3zone_multistage/run_gurobi.jl
+++ b/examples/electricity_3zone_multistage/run_gurobi.jl
@@ -1,6 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
-                    optimizer=Gurobi.Optimizer,
-                    optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8));
+(case, solution) = run_case(@__DIR__;
+    optimizer=Gurobi.Optimizer,
+    optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
+);

--- a/examples/multisector_3zone/run.jl
+++ b/examples/multisector_3zone/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/multisector_3zone/run_gurobi.jl
+++ b/examples/multisector_3zone/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/multisector_3zone/run_with_env.jl
+++ b/examples/multisector_3zone/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);

--- a/examples/multisector_3zone_CSVinputs/run.jl
+++ b/examples/multisector_3zone_CSVinputs/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/multisector_3zone_CSVinputs/run_gurobi.jl
+++ b/examples/multisector_3zone_CSVinputs/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/multisector_3zone_CSVinputs/run_with_env.jl
+++ b/examples/multisector_3zone_CSVinputs/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);

--- a/examples/multisector_3zone_simpleCSVinputs/run.jl
+++ b/examples/multisector_3zone_simpleCSVinputs/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/multisector_3zone_simpleCSVinputs/run_gurobi.jl
+++ b/examples/multisector_3zone_simpleCSVinputs/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/multisector_3zone_simpleCSVinputs/run_with_env.jl
+++ b/examples/multisector_3zone_simpleCSVinputs/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);

--- a/examples/multisector_3zone_simpleinputs/run.jl
+++ b/examples/multisector_3zone_simpleinputs/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/multisector_3zone_simpleinputs/run_gurobi.jl
+++ b/examples/multisector_3zone_simpleinputs/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/multisector_3zone_simpleinputs/run_with_env.jl
+++ b/examples/multisector_3zone_simpleinputs/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);

--- a/examples/steel_3zone/run.jl
+++ b/examples/steel_3zone/run.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using HiGHS
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=HiGHS.Optimizer,
     optimizer_attributes=("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3)
 );

--- a/examples/steel_3zone/run_gurobi.jl
+++ b/examples/steel_3zone/run_gurobi.jl
@@ -1,7 +1,7 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; 
+(case, solution) = run_case(@__DIR__; 
     optimizer=Gurobi.Optimizer,
     optimizer_attributes=("Method" => 2, "Crossover" => 1, "BarConvTol" => 1e-8)
 );

--- a/examples/steel_3zone/run_with_env.jl
+++ b/examples/steel_3zone/run_with_env.jl
@@ -5,4 +5,4 @@ if !(@isdefined GRB_ENV)
     const GRB_ENV = Gurobi.Env()
 end
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);
+(case, solution) = run_case(@__DIR__; optimizer=Gurobi.Optimizer, optimizer_env=GRB_ENV);


### PR DESCRIPTION
This commit updates the examples following the merge of [PR #239](https://github.com/macroenergy/MacroEnergy.jl/pull/239) of MacroEnergy. The `run_case` function now returns the full `Case` object instead of a vector of systems:

**before**:
```julia
julia> (systems, model) = run_case(@__DIR__, ...);
julia> typeof(systems)
Vector{System}
```

**now**:
```julia
julia> (case, solution) = run_case(@__DIR__, ...);
julia> typeof(case)
Case
```